### PR TITLE
Pull container rev_number instead of container branch revision

### DIFF
--- a/fullmetalupdate/updater.py
+++ b/fullmetalupdate/updater.py
@@ -153,7 +153,7 @@ class AsyncUpdater(object):
             progress.connect('changed', OSTree.Repo.pull_default_console_progress_changed, None)
 
             opts = GLib.Variant('a{sv}', {'flags':GLib.Variant('i', OSTree.RepoPullFlags.NONE), 
-                                          'refs': GLib.Variant('as', (container_name,)),
+                                          'refs': GLib.Variant('as', (rev_number,)),
                                           'depth': GLib.Variant('i', OSTREE_DEPTH)})
             self.logger.info("Pulling remote {} from OSTree repo, branch ({})".format(container_name, container_name))
             res = self.repo_containers.pull_with_options(container_name, opts, progress, None)


### PR DESCRIPTION
The client was pulling the `container_name`, which actually points to
the last commit of the `container_name` branch. Because of this, the
client was not able to checkout to the proper commit because the commit
was not found.

Say you have 3 chronologically ordered commits c1, c2 and c3, the
depth is set to 1, and you want to pull c1. This is what happened :

```
          c1  ← rev_number
          ↓
       ↑  c2
Pulled |  ↓
       ↓  c3  ← container_name
```

So since c2 and c3 only are pulled the client could not checkout to c1
unless the depth was increased by 1, which actually fixes
https://github.com/FullMetalUpdate/meta-fullmetalupdate-extra/issues/12