### PR TITLE
Fix incompatible double slash with recent hawkbit versions

### DIFF
--- a/rauc_hawkbit/ddi/cancel_action.py
+++ b/rauc_hawkbit/ddi/cancel_action.py
@@ -28,7 +28,7 @@ class Action(object):
         See http://sp.apps.bosch-iot-cloud.com/documentation/rest-api/rootcontroller-api-guide.html#_get_tenant_controller_v1_targetid_cancelaction_actionid # noqa
         """
         return await self.ddi.get_resource(
-            '/{tenant}/controller/v1/{controllerId}/cancelAction/{actionId}', actionId=self.action_id)
+            '{tenant}/controller/v1/{controllerId}/cancelAction/{actionId}', actionId=self.action_id)
 
     async def feedback(self, status_execution, status_result,
                        status_details=()):
@@ -57,7 +57,7 @@ class Action(object):
         }
 
         return await self.ddi.post_resource(
-            '/{tenant}/controller/v1/{controllerId}/cancelAction/{actionId}/feedback', post_data, actionId=self.action_id)
+            '{tenant}/controller/v1/{controllerId}/cancelAction/{actionId}/feedback', post_data, actionId=self.action_id)
 
 
 class CancelAction(object):

--- a/rauc_hawkbit/ddi/client.py
+++ b/rauc_hawkbit/ddi/client.py
@@ -80,7 +80,7 @@ class DDIClient(object):
 
         Returns: JSON data
         """
-        return await self.get_resource('/{tenant}/controller/v1/{controllerId}')
+        return await self.get_resource('{tenant}/controller/v1/{controllerId}')
 
     async def configData(self, status_execution, status_result, action_id='',
                          status_details=(), **kwdata):
@@ -123,7 +123,7 @@ class DDIClient(object):
             'data': kwdata
         }
 
-        await self.put_resource('/{tenant}/controller/v1/{controllerId}/configData', put_data)
+        await self.put_resource('{tenant}/controller/v1/{controllerId}/configData', put_data)
 
 
     def build_api_url(self, api_path):

--- a/rauc_hawkbit/ddi/deployment_base.py
+++ b/rauc_hawkbit/ddi/deployment_base.py
@@ -30,7 +30,7 @@ class DeploymentBaseAction(object):
 
     async def __call__(self, resource=None):
         return await self.ddi.get_resource(
-            '/{tenant}/controller/v1/{controllerId}/deploymentBase/{actionId}', {'c': resource}, actionId=self.action_id)
+            '{tenant}/controller/v1/{controllerId}/deploymentBase/{actionId}', {'c': resource}, actionId=self.action_id)
 
     async def feedback(self, status_execution, status_result,
                        status_details=(), **kwstatus_result_progress):
@@ -60,7 +60,7 @@ class DeploymentBaseAction(object):
         }
 
         return await self.ddi.post_resource(
-            '/{tenant}/controller/v1/{controllerId}/deploymentBase/{actionId}/feedback', post_data, actionId=self.action_id)
+            '{tenant}/controller/v1/{controllerId}/deploymentBase/{actionId}/feedback', post_data, actionId=self.action_id)
 
 
 class DeploymentBase(object):

--- a/rauc_hawkbit/ddi/softwaremodules.py
+++ b/rauc_hawkbit/ddi/softwaremodules.py
@@ -15,7 +15,7 @@ class FileName(object):
         See http://sp.apps.bosch-iot-cloud.com/documentation/rest-api/rootcontroller-api-guide.html#_get_tenant_controller_v1_targetid_softwaremodules_softwaremoduleid_artifacts_filename # noqa
         """
         return await self.ddi.get_binary_resource(
-            '/{tenant}/controller/v1/{controllerId}/softwaremodules/{moduleId}/artifacts/{filename}', bundle_dl_location, moduleId=self.software_module_id,
+            '{tenant}/controller/v1/{controllerId}/softwaremodules/{moduleId}/artifacts/{filename}', bundle_dl_location, moduleId=self.software_module_id,
             filename=self.file_name)
 
     async def MD5SUM(self, md5_dl_location):
@@ -23,7 +23,7 @@ class FileName(object):
         See http://sp.apps.bosch-iot-cloud.com/documentation/rest-api/rootcontroller-api-guide.html#_get_tenant_controller_v1_targetid_softwaremodules_softwaremoduleid_artifacts_filename_md5sum # noqa
         """
         return await self.ddi.get_binary_resource(
-            '/{tenant}/controller/v1/{controllerId}/softwaremodules/{moduleId}/artifacts/{filename}', md5_dl_location, mime='text/plain', moduleId=self.software_module_id,
+            '{tenant}/controller/v1/{controllerId}/softwaremodules/{moduleId}/artifacts/{filename}', md5_dl_location, mime='text/plain', moduleId=self.software_module_id,
             filename=self.file_name)
 
 
@@ -41,7 +41,7 @@ class Artifacts(object):
         See http://sp.apps.bosch-iot-cloud.com/documentation/rest-api/rootcontroller-api-guide.html#_get_tenant_controller_v1_targetid_softwaremodules_softwaremoduleid_artifacts # noqa
         """
         return await self.ddi.get_resource(
-            '/{tenant}/controller/v1/{controllerId}/softwaremodules/{moduleId}/artifacts', moduleId=self.software_module_id)
+            '{tenant}/controller/v1/{controllerId}/softwaremodules/{moduleId}/artifacts', moduleId=self.software_module_id)
 
     def __getitem__(self, key):
         filename = key


### PR DESCRIPTION
Fixes (for example) :
```
API error: {"timestamp":"2020-07-08T13:03:14.943+0000","status":500,"error":"Internal Server Error","message":"org.springframework.security.web.firewall.RequestRejectedException: The request was rejected because the URL was not normalized.","path":"//DEFAULT/controller/v1/FullMetalUpdate_Demo/deploymentBase/1/feedback"}
```