### PR TITLE
Add support for updates where both OS and apps are updated

### DIFF
--- a/fullmetalupdate/fullmetalupdate_ddi_client.py
+++ b/fullmetalupdate/fullmetalupdate_ddi_client.py
@@ -145,7 +145,6 @@ class FullMetalUpdateDDIClient(AsyncUpdater):
         action_id, resource = match.groups()
         # fetch deployment information
         deploy_info = await self.ddi.deploymentBase[action_id](resource)
-        reboot_needed = False
 
         chunks_qty = len(deploy_info['deployment']['chunks'])
 
@@ -157,6 +156,7 @@ class FullMetalUpdateDDIClient(AsyncUpdater):
                 status_execution, status_result, [msg])
             raise APIError(msg)
         else:
+            # problem ?
             msg = "FullMetalUpdate:Proceeding"
             percentage = {"cnt": 0, "of": chunks_qty}
             status_execution = DeploymentStatusExecution.proceeding
@@ -166,7 +166,7 @@ class FullMetalUpdateDDIClient(AsyncUpdater):
                 percentage=percentage)
 
         self.action_id = action_id
-
+        final_result_os = True
         seq = ('name', 'version', 'rev', 'part', 'autostart', 'autoremove', 'status_execution', 'status_update', 'status_result', 'notify', 'timeout')
         updates = []
 
@@ -196,33 +196,40 @@ class FullMetalUpdateDDIClient(AsyncUpdater):
                 # checking if we just rebooted and we need to send the feedback in which
                 # case we don't need to pull the update image again
                 [feedback, reboot_data] = self.feedback_for_os_deployment(update['rev'])
-                if feedback:
-                    await self.ddi.deploymentBase[reboot_data['action_id']].feedback(
-                        DeploymentStatusExecution(reboot_data['status_execution']),
-                        DeploymentStatusResult(reboot_data['status_result']),
-                        [reboot_data['msg']])
-                    self.action_id = None
-                    return
+                if feedback: 
+                    final_result_os = (DeploymentStatusResult(reboot_data['status_result']) == DeploymentStatusResult.success)
+                    if not final_result_os:
+                        self.logger.info(reboot_data['msg'])
+                        await self.ddi.deploymentBase[reboot_data['action_id']].feedback(
+                            DeploymentStatusExecution(reboot_data['status_execution']),
+                            DeploymentStatusResult(reboot_data['status_result']),
+                            [reboot_data['msg']])
+                        action_id = None
+                        return
 
-                self.logger.info("OS {} v.{} - updating...".format(update['name'], update['version']))
-                update['status_update'] = self.update_system(update['rev'])
-                update['status_execution'] = DeploymentStatusExecution.closed
-                if not update['status_update']:
-                    msg = "OS {} v.{} Deployment failed".format(update['name'], update['version'])
-                    self.logger.error(msg)
-                    update['status_result'] = DeploymentStatusResult.failure
-                    await self.ddi.deploymentBase[self.action_id].feedback(
-                        update['status_execution'], update['status_result'], [msg])
-                    return
                 else:
-                    msg = "OS {} v.{} Deployment succeed".format(update['name'], update['version'])
-                    self.logger.info(msg)
-                    update['status_result'] = DeploymentStatusResult.success
-                    reboot_needed = True
-                    self.write_reboot_data(self.action_id,
-                                           update['status_execution'],
-                                           update['status_result'],
-                                           msg)
+                    self.logger.info("OS {} v.{} - updating...".format(update['name'], update['version']))
+                    update['status_update'] = self.update_system(update['rev'])
+                    update['status_execution'] = DeploymentStatusExecution.closed
+                    if not update['status_update']:
+                        msg = "OS {} v.{} Deployment failed".format(update['name'], update['version'])
+                        self.logger.error(msg)
+                        update['status_result'] = DeploymentStatusResult.failure
+                        await self.ddi.deploymentBase[self.action_id].feedback(
+                            update['status_execution'], update['status_result'], [msg])
+                        return
+                    else:
+                        msg = "OS {} v.{} Deployment succeed".format(update['name'], update['version'])
+                        self.logger.info(msg)
+                        update['status_result'] = DeploymentStatusResult.success
+                        self.write_reboot_data(self.action_id,
+                                            update['status_execution'],
+                                            update['status_result'],
+                                            msg)
+                        try:
+                            subprocess.run("reboot")
+                        except subprocess.CalledProcessError as e:
+                            self.logger.error("Reboot failed: {}".format(e))
 
             elif update['part'] == 'bApp':
                 self.logger.info("App {} v.{} - updating...".format(update['name'], update['version']))
@@ -241,8 +248,9 @@ class FullMetalUpdateDDIClient(AsyncUpdater):
         for update in updates:
             update['status_update'] &= self.handle_container(update['name'], update['autostart'], update['autoremove'])
 
-        final_result = True
+        final_result_apps = True
         fails = ""
+        feedbackMsg = ""
         feedbackThreadIt = iter(self.feedbackThreads)
 
         # Hawkbit server feedback process
@@ -255,33 +263,35 @@ class FullMetalUpdateDDIClient(AsyncUpdater):
                 self.mutexResults.release()
 
             if not update['status_update']:
-               msg = "App {} v.{} Deployment failed\n {}".format(update['name'], update['version'], feedbackMsg)
-               self.logger.error(msg)
-               update['status_result'] = DeploymentStatusResult.failure
-               fails += update['name'] + " "
+                msg = "App {} v.{} Deployment failed : {}\n".format(update['name'], update['version'], feedbackMsg)
+                notifyMsg = msg
+                self.logger.error(msg)
+                update['status_result'] = DeploymentStatusResult.failure
+                fails += update['name'] + " "
             else:
-               msg = "App {} v.{} Deployment succeed".format(update['name'], update['version'])
-               self.logger.info(msg)
-               update['status_result'] = DeploymentStatusResult.success
+                msg = "App {} v.{} Deployment succeed\n".format(update['name'], update['version'])
+                notifyMsg += msg
+                self.logger.info(msg)
+                update['status_result'] = DeploymentStatusResult.success
 
-            final_result &= (update['status_result'] == DeploymentStatusResult.success)
-        
-        if(final_result):
-            msg = "Hawkbit Update Success : All applications have been updated and correctly restarted."
-            self.logger.info(msg)
+            final_result_apps &= (update['status_result'] == DeploymentStatusResult.success)
+
+        if updates:
+            if(final_result_apps):
+                msg = "Hawkbit Update Success : All applications have been updated and correctly restarted."
+                self.logger.info(msg)
+                status_result = DeploymentStatusResult.success
+            else:
+                msg = "Hawkbit Update Failure : " + fails + "failed to update and / or to restart."
+                self.logger.error(msg)
+                status_result = DeploymentStatusResult.failure
+            notifyMsg = msg + "\n" + notifyMsg
+        if feedback:
+            notifyMsg += reboot_data['msg']
             status_result = DeploymentStatusResult.success
-        else:
-            msg = "Hawkbit Update Failure : " + fails + "failed to update and / or to restart."
-            self.logger.error(msg)
-            status_result = DeploymentStatusResult.failure
-        await self.ddi.deploymentBase[self.action_id].feedback(DeploymentStatusExecution.closed, status_result, [msg])
-
+            
+        await self.ddi.deploymentBase[self.action_id].feedback(DeploymentStatusExecution.closed, status_result, [notifyMsg])
         self.action_id = None
-        if reboot_needed:
-            try:
-                subprocess.run("reboot")
-            except subprocess.CalledProcessError as e:
-                self.logger.error("Reboot failed: {}".format(e))
 
     async def sleep(self, base):
         """ 


### PR DESCRIPTION
With the mixed updates (OS + apps), we had two issues : 
- first, we didn't know if it would just work ;
- second, we didn't know in which order the chunks would be processed (OS then Apps, App A then OS then App B, etc) ;

Here is the behaviour we want to implement.
1) The OS chunk is processed first
2) The system reboots
3) When the FMU client gets back online, we check if the deployment went well : if so, we can just jump right to the container chunks. If not, we stop the update and send a negative feedback to the Hawkbit server.
4) Then, we process the container chunks. The order here does not really matter here
5) Finally, we feedback the Hawkbit server with the final results of the update . For example, the rev of the OS deployment has been well deployed (normally if we arrived here that's because the OS deployment was imperatively successful), app A was successfully updated and restarted, app B failed to be restarted, ...

The first commit implements the behaviour described above.
Regarding the order of the chunks, chunks arrive in the same order the user drags and drops the "software updates" when creating a new Hawkbit "distribution" on Hawkbit Web Client. To force OS chunks to always be processed first, we implement a small algorithm to always push the OS chunk first in the list. (please see the second commit) 